### PR TITLE
Emit const-qualified memoryview return types for pandas 3.0 compatibility

### DIFF
--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -29,7 +29,8 @@ from modelx_cython.parser import ModuleVisitor, LexicalCellsInfo, LexicalRefInfo
 
 from modelx_cython.consts import (
     SPACE_PREF,
-    MODULE_PREF
+    MODULE_PREF,
+    CY_MOD
 )
 from modelx_cython.typedefs import str_to_type, normalize_type
 
@@ -92,7 +93,13 @@ class CombinedCellsInfo(LexicalCellsInfo):
         if self.has_typeinfo():
             typ = get_type_expr(self.norm_type, c_style=c_style)
             if self.is_real_value and self.is_array_returned:
-                return typ + "[" + ", ".join(":" * self._rt.ret_type.ndim) + "]"
+                # const element type so that read-only arrays, such as those
+                # returned by pandas under copy-on-write, can be coerced
+                suffix = "[" + ", ".join(":" * self._rt.ret_type.ndim) + "]"
+                if c_style:
+                    return "const " + typ + suffix
+                else:
+                    return f"{CY_MOD}.const[{typ}]" + suffix
             else:
                 return typ
         else:


### PR DESCRIPTION
## Summary

Cells that return numeric arrays are now declared with **const-qualified memoryview return types**:

- `.pxd` declarations (via `PXDGenerator`): `const long long[:]`, `const double[:, :]`
- pure-Python annotations (via `ModuleTransformer`): `_mx_cy.const[_mx_cy.longlong][:]`, etc.

Both generators obtain these strings from the single `CombinedCellsInfo.get_rettype_expr` method, so the change is made there once and the `.pxd` and `.py` declarations stay in sync. The `const` automatically extends to the `_v_*` cache attributes, which is required for the generated getter pattern `val = self._v_x = self._f_x()` to compile (a const view cannot be assigned into a non-const attribute).

Scalar and `object` returns are unchanged: `const` on a by-value C return is ignored by the C standard, and `const object` is not a valid Cython type.

## Motivation

pandas 3.0 makes copy-on-write mandatory, so `Series.to_numpy()` returns a **read-only** zero-copy view whenever no dtype conversion is needed. Coercing such an array into a non-const memoryview requests a writable buffer and fails; models like lifelib's `BasicTerm_SC`, whose `Data` space feeds `to_numpy()` results into memoryview-typed cells, crashed at runtime with:

```
File "BasicTerm_SC_nomx_cy/_mx_classes.py", line 1298, in _c_Data._f_policy_term
ValueError: buffer source array is read-only
```

A `const` element type makes Cython request a read-only buffer instead, which accepts both writable and read-only arrays with no copying.

## Verification

Full test suite on Windows / Python 3.13.9 / Cython 3.2.4 / pandas 3.0.0 / numpy 2.3.3: **21 passed, 0 failed, 7 skipped** (the skips are the pre-existing, intentionally disabled `main`-target variants). This includes `test_mx2cy_with_lifelib[mx2cy-basicterm_sc-BasicTerm_SC]`, which fails on `main` under pandas 3.0 with the error above and passes with this change.

## Behavioral note

A user formula that mutates an array obtained from another cells (e.g. `arr = data.disc_rate(); arr[t] = x`) now fails at cythonize time with "Assignment to const dereference" instead of compiling and mutating the shared cache. Mutating another cells' cached result already violates modelx semantics, so this turns a silent hazard into a compile-time error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
