### PR TITLE
Collapse return type to object on array/non-array mismatch

### DIFF
--- a/modelx_cython/tests/test_tracer.py
+++ b/modelx_cython/tests/test_tracer.py
@@ -1,0 +1,48 @@
+import logging
+
+import numpy as np
+import pytest
+
+from modelx_cython.tracer import ReturnTypeInfo, RuntimeCellsInfo
+from modelx_cython.monkeytype_tracing import CallTrace
+
+
+def foo(self, i):
+    pass
+
+
+def make_trace(ret_val, i):
+    return CallTrace(foo, {"self": None, "i": i}, ret_val=ret_val)
+
+
+@pytest.mark.parametrize("ret_vals", [
+    [np.array([1.0, 2.0]), 3],
+    [3, np.array([1.0, 2.0])],
+    [np.array([1.0, 2.0]), 3, np.array([1.0, 2.0])]
+])
+def test_ret_type_array_and_non_array(ret_vals, caplog):
+    """Array and non-array values returned from the same cells collapse to object"""
+    traces = [make_trace(val, i) for i, val in enumerate(ret_vals)]
+    with caplog.at_level(logging.INFO, logger="modelx_cython.tracer"):
+        info = RuntimeCellsInfo(traces)
+
+    assert info.ret_type == ReturnTypeInfo(object)
+    msgs = [r.message for r in caplog.records
+            if "varying array and non-array types returned from" in r.message]
+    assert len(msgs) == 1
+    assert "array of float64" in msgs[0]
+    assert "int" in msgs[0]
+
+
+def test_ret_type_varying_non_array_types(caplog):
+    """Both conflicting types appear in the log for non-array return values"""
+    traces = [make_trace(1, 0), make_trace("abc", 1)]
+    with caplog.at_level(logging.INFO, logger="modelx_cython.tracer"):
+        info = RuntimeCellsInfo(traces)
+
+    assert info.ret_type == ReturnTypeInfo(object)
+    msgs = [r.message for r in caplog.records
+            if "varying types returned from" in r.message]
+    assert len(msgs) == 1
+    assert "int for i=0" in msgs[0]
+    assert "str for i=1" in msgs[0]

--- a/modelx_cython/tracer.py
+++ b/modelx_cython/tracer.py
@@ -135,6 +135,7 @@ class RuntimeCellsInfo:     # TODO: Create base class RuntimeBaseMemberInfo
         was_dtype_logged = False
         was_ndim_logged = False
         was_vtype_logged = False
+        was_mixed_logged = False
 
         def get_arg_expr(args):
             return ", ".join(f"{k}={str(v)}" for k, v in itertools.islice(args.items(), 1, None))
@@ -192,10 +193,21 @@ class RuntimeCellsInfo:     # TODO: Create base class RuntimeBaseMemberInfo
                             args0 = get_arg_expr(last_args)
                             args1 = get_arg_expr(tr.arg_vals)
                             msg0 = f"{last_tp.value_type.__name__} for {args0}"
-                            msg1 = f"{last_tp.value_type.__name__} for {args1}"
+                            msg1 = f"{tp.value_type.__name__} for {args1}"
                             _logger.info(f"varying types returned from {self.fqname}:{msg0} and {msg1}")
                             was_vtype_logged = True
                         last_tp.value_type = object
+
+                else:   # one is an array, the other is not
+                    if not was_mixed_logged:
+                        args0 = get_arg_expr(last_args)
+                        args1 = get_arg_expr(tr.arg_vals)
+                        msg0 = f"{'array of ' if last_tp.is_array else ''}{last_tp.value_type.__name__} for {args0}"
+                        msg1 = f"{'array of ' if tp.is_array else ''}{tp.value_type.__name__} for {args1}"
+                        _logger.info(f"varying array and non-array types returned from {self.fqname}:{msg0} and {msg1}")
+                        was_mixed_logged = True
+
+                    last_tp = ReturnTypeInfo(object)
 
             else:
                 last_tp = tp


### PR DESCRIPTION
## What changed

`RuntimeCellsInfo._init_ret_type` in `modelx_cython/tracer.py` merges return types across sampled calls, but had no branch for the case where one trace returns a `np.ndarray` and another returns a non-array value. The conflicting trace was silently ignored and the first-observed type won, so a cells function that sometimes returns an array and sometimes a scalar could be exported with a typed memoryview return type. This adds the missing branch: the return type collapses to `ReturnTypeInfo(object)` and an INFO message (`varying array and non-array types returned from ...`) is logged once, matching the style of the existing dtype/ndim/scalar mismatch cases.

Also fixes the non-array mismatch log message, which used `last_tp.value_type.__name__` for both operands — e.g. it logged `int for i=0 and int for i=1` when the second call actually returned a `str`. It now prints the second trace''s type name.

## Tests

New unit tests in `modelx_cython/tests/test_tracer.py`:

- `test_ret_type_array_and_non_array` covers array-then-scalar, scalar-then-array, and array/scalar/array orderings, asserting the collapse to `ReturnTypeInfo(object)` and that the log fires exactly once (the three-trace case exercises the dedup guard).
- `test_ret_type_varying_non_array_types` pins the log fix by asserting both type names appear (`int for i=0` and `str for i=1`).

All four tests fail against the previous code with exactly the expected failure modes, and pass with this change.

## Notes for reviewers

- `ReturnTypeInfo(object)` (`is_array=False, ndim=0`) is bitwise-identical to the state the pre-existing scalar-type-mismatch path already produces, so code generation downstream (`builder.py` / `transformer.py`) already handles it: `is_real_value` and `is_array_returned` are both false, and a plain `object` declaration is emitted.
- Once collapsed to `object`, no later trace can re-narrow the type; a later conflicting trace after the collapse may emit one additional, slightly redundant INFO line (the `object` sentinel is indistinguishable from a real observation), consistent with the existing collapse branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)