### PR TITLE
Auto-detect memoryview vs object return types via static usage analysis

### DIFF
--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -12,8 +12,11 @@ import numbers
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Sequence, Mapping, Dict, Tuple
+from typing import Union, Sequence, Mapping, Dict, Optional, Tuple, TYPE_CHECKING
 import logging
+
+if TYPE_CHECKING:
+    from modelx_cython.usage import UsageVerdict
 
 try:
     from types import NoneType
@@ -36,12 +39,19 @@ from modelx_cython.typedefs import str_to_type, normalize_type
 
 _logger = logging.getLogger(__name__)
 
+# Policy for array-returning cells with no call sites inside the model
+# (consumed only by external user scripts, which the usage analysis cannot
+# see). True keeps the const-memoryview return type; False falls back to
+# object.
+MEMORYVIEW_FOR_EXTERNAL_ONLY_ARRAYS: bool = True
+
 
 class CombinedCellsInfo(LexicalCellsInfo):
     parent: 'ClassInfo'
     _rt: RuntimeCellsInfo
     _spec: dict
     _spec_ret_t: str
+    usage: 'Optional[UsageVerdict]' = None  # set by usage.apply_verdicts
 
     def __init__(self, cls_info, lx_info, rt_info, spec) -> None:
         super().__init__(
@@ -51,11 +61,26 @@ class CombinedCellsInfo(LexicalCellsInfo):
         self._rt = rt_info
         self._spec = spec
         self._spec_ret_t = spec.get(TransSpec.RET_T, "")
+        self._force_memoryview = self._spec_ret_t == TransSpec.RET_MEMORYVIEW
+        if self._force_memoryview:
+            if self.has_typeinfo():
+                if not (self.is_array_returned and self.is_real_value
+                        and self.ret_ndim >= 1):
+                    raise ValueError(
+                        f"invalid value for spec '{TransSpec.RET_T}': "
+                        f"'{TransSpec.RET_MEMORYVIEW}' requires a real-valued "
+                        f"numpy array return, but '{self.fqname}' does not "
+                        "return one")
+            else:
+                _logger.warning(
+                    f"spec '{TransSpec.RET_T}': '{TransSpec.RET_MEMORYVIEW}' "
+                    f"for '{self.fqname}' is ignored because no type "
+                    "information was sampled")
 
     @cached_property
     def norm_type(self) -> type:
         if self.has_typeinfo():
-            if self._spec_ret_t:
+            if self._spec_ret_t and not self._force_memoryview:
                 if self._spec_ret_t in str_to_type:
                     return str_to_type[self._spec_ret_t]
                 else:
@@ -81,6 +106,29 @@ class CombinedCellsInfo(LexicalCellsInfo):
     def has_args(self):
         return bool(self.params)
 
+    @property
+    def ret_ndim(self) -> int:
+        assert self.has_typeinfo()
+        return self._rt.ret_type.ndim
+
+    @property
+    def has_spec_rettype(self) -> bool:
+        return bool(self._spec_ret_t)
+
+    @property
+    def use_memoryview(self) -> bool:
+        # A plain property, not cached: `usage` is assigned after
+        # construction, between the build and transform phases.
+        if self._force_memoryview:
+            return True
+        if self.usage is None:
+            return True     # no analysis info: keep legacy behavior
+        if not self.usage.only_element_access:
+            return False
+        if not self.usage.has_internal_uses:
+            return MEMORYVIEW_FOR_EXTERNAL_ONLY_ARRAYS
+        return True
+
     def get_argtype_expr(self, arg: str, c_style=False) -> str:
         if self.has_typeinfo():
             assert arg in self._rt.arg_types
@@ -93,6 +141,8 @@ class CombinedCellsInfo(LexicalCellsInfo):
         if self.has_typeinfo():
             typ = get_type_expr(self.norm_type, c_style=c_style)
             if self.is_real_value and self.is_array_returned:
+                if not self.use_memoryview:
+                    return "object"
                 # const element type so that read-only arrays, such as those
                 # returned by pandas under copy-on-write, can be coerced
                 suffix = "[" + ", ".join(":" * self._rt.ret_type.ndim) + "]"
@@ -210,7 +260,8 @@ class ClassInfo:
         self._add_space_params()
 
     def _init_cells(self):
-        for name, lx_info in self.visitor.cells_info[self.name].items():
+        # .get: model classes and container-only spaces have no cells
+        for name, lx_info in self.visitor.cells_info.get(self.name, {}).items():
             rt_info = self.logger.cells_info.get(lx_info.fqname, None)
             self.cells[name] = CombinedCellsInfo(
                 self,

--- a/modelx_cython/cli.py
+++ b/modelx_cython/cli.py
@@ -20,6 +20,7 @@ import shutil
 import runpy
 import ast
 import argparse
+import dataclasses
 import logging
 import subprocess
 from typing import IO, TYPE_CHECKING, Sequence, Optional, Tuple
@@ -30,6 +31,7 @@ from modelx_cython.tracer import trace_calls, MxCallTraceLogger, MxCodeFilter
 from modelx_cython.builder import ModuleInfo
 from modelx_cython.parser import ModuleVisitor
 from modelx_cython.transformer import ModuleTransformer, PXDGenerator
+from modelx_cython.usage import analyze_usage, apply_verdicts
 
 
 def increment_backups(
@@ -77,6 +79,28 @@ class HandlerError(Exception):
     pass
 
 
+@dataclasses.dataclass
+class _TransUnit:
+    """One module's parsed state between the build and transform phases."""
+    fqname: str
+    source: str
+    visitor: ModuleVisitor
+    module_info: ModuleInfo
+    abs_src_path: pathlib.Path
+    rel_src_path: pathlib.Path
+    abs_pxd_path: pathlib.Path
+    abs_init_path: pathlib.Path
+
+
+def iter_module_files(model_path: pathlib.Path):
+    """Yield (module fqname, path) for every model/space module under
+    model_path. fqnames are rooted at model_path.name."""
+    for name in (MX_MODEL_MOD, MX_SPACE_MOD):
+        for path in sorted(model_path.rglob(name + ".py")):
+            rel = path.relative_to(model_path.parent).with_suffix("")
+            yield ".".join(rel.parts), path
+
+
 def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> int:
 
     orig_path = pathlib.Path(args.model_path).resolve()
@@ -103,6 +127,9 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
         rel_model_path = model_path.relative_to(model_path.parent)
 
         modules = [rel_model_path / (MX_SYS_MOD + ".py")]
+
+        # Phase 1: parse all sources and build all module infos
+        units = []
         for m in logger.modules:
             subs = m.split(".")
             assert subs.pop(0) == model_path.name
@@ -117,13 +144,32 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
             source = abs_src_path.read_text()
             visitor = ModuleVisitor(module=m, source=source)
             module_info = ModuleInfo(m, visitor, logger, spec)
-            trans = ModuleTransformer(source, module_info)
-            pxd = PXDGenerator(module_info)
+            units.append(_TransUnit(
+                m, source, visitor, module_info,
+                abs_src_path, rel_src_path, abs_pxd_path, abs_init_path))
 
-            abs_src_path.write_text(trans.transformed.code)
-            abs_pxd_path.write_text(pxd.code)
-            abs_init_path.write_text("from . cimport _mx_classes")
-            modules.append(rel_src_path)
+        # Phase 2: classify cross-module usage of array-returning cells
+        # so that get_rettype_expr can fall back to object where needed.
+        # Modules whose cells the sample never exercised are not transformed,
+        # but their formulas may still consume traced cells, so they are
+        # parsed for the analysis as well.
+        pairs = [(u.visitor, u.module_info) for u in units]
+        traced = {u.fqname for u in units}
+        for m, src_path in iter_module_files(model_path):
+            if m not in traced:
+                visitor = ModuleVisitor(module=m, source=src_path.read_text())
+                pairs.append((visitor, ModuleInfo(m, visitor, logger, spec)))
+        apply_verdicts(pairs, analyze_usage(pairs))
+
+        # Phase 3: transform and write out
+        for u in units:
+            trans = ModuleTransformer(u.source, u.module_info)
+            pxd = PXDGenerator(u.module_info)
+
+            u.abs_src_path.write_text(trans.transformed.code)
+            u.abs_pxd_path.write_text(pxd.code)
+            u.abs_init_path.write_text("from . cimport _mx_classes")
+            modules.append(u.rel_src_path)
 
         create_setup(model_name, modules=modules, setup_file=setup_file)
 

--- a/modelx_cython/config.py
+++ b/modelx_cython/config.py
@@ -30,6 +30,7 @@ class TransSpec:
     CELLS_PARAMS = "cells_params"   # deprecated
     SIZE = "size"   # deprecated
     RET_T = "return_type"
+    RET_MEMORYVIEW = "memoryview"   # RET_T value forcing memoryview emission
     PARAM_T = "param_type"
 
     def __init__(self, data: dict) -> None:

--- a/modelx_cython/tests/samples/array_usage/ArrayUsage/Consumer/__init__.py
+++ b/modelx_cython/tests/samples/array_usage/ArrayUsage/Consumer/__init__.py
@@ -1,0 +1,25 @@
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def use_elem(t):
+    return data.arr_cross_elem()[t] + 1.0
+
+
+def use_whole():
+    return float(data.arr_cross_whole().sum())
+
+
+# ---------------------------------------------------------------------------
+# References
+
+data = ("Interface", ("..", "Data"), "auto")

--- a/modelx_cython/tests/samples/array_usage/ArrayUsage/Data/__init__.py
+++ b/modelx_cython/tests/samples/array_usage/ArrayUsage/Data/__init__.py
@@ -1,0 +1,55 @@
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def arr_elem():
+    return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+def elem(i):
+    return arr_elem()[i] * 2.0
+
+
+def arr2d():
+    return np.array([[1.0, 2.0], [3.0, 4.0]])
+
+
+def elem2d(i):
+    return arr2d()[i, 1]
+
+
+def arr_whole():
+    return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+def whole_sum():
+    return float((arr_whole() * 2.0).sum())
+
+
+def arr_sliced():
+    return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+def sliced_prod():
+    return float(sum(list(elem(t) for t in range(3)) * arr_sliced()[:3]))
+
+
+def arr_cross_elem():
+    return np.array([10.0, 20.0, 30.0])
+
+
+def arr_cross_whole():
+    return np.array([1.5, 2.5, 3.5])
+
+
+def arr_external():
+    return np.array([7.0, 8.0, 9.0])

--- a/modelx_cython/tests/samples/array_usage/ArrayUsage/__init__.py
+++ b/modelx_cython/tests/samples/array_usage/ArrayUsage/__init__.py
@@ -1,0 +1,15 @@
+from modelx.serialize.jsonvalues import *
+
+_name = "ArrayUsage"
+
+_allow_none = False
+
+_spaces = [
+    "Data",
+    "Consumer"
+]
+
+# ---------------------------------------------------------------------------
+# References
+
+np = ("Module", "numpy")

--- a/modelx_cython/tests/samples/array_usage/ArrayUsage/_system.json
+++ b/modelx_cython/tests/samples/array_usage/ArrayUsage/_system.json
@@ -1,0 +1,1 @@
+{"modelx_version": [0, 28, 0], "serializer_version": 6}

--- a/modelx_cython/tests/samples/array_usage/assert_cy.py
+++ b/modelx_cython/tests/samples/array_usage/assert_cy.py
@@ -1,0 +1,29 @@
+import math
+import numpy as np
+from ArrayUsage_nomx_cy import mx_model
+
+arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+for i in range(3):
+    assert math.isclose(mx_model.Data.elem(i), arr[i] * 2.0)
+
+arr2d = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+for i in range(2):
+    assert math.isclose(mx_model.Data.elem2d(i), arr2d[i, 1])
+
+assert math.isclose(mx_model.Data.whole_sum(), float((arr * 2.0).sum()))
+
+expected = float(sum([arr[t] * 2.0 for t in range(3)] * arr[:3]))
+assert math.isclose(mx_model.Data.sliced_prod(), expected)
+
+cross_elem = np.array([10.0, 20.0, 30.0])
+
+for t in range(3):
+    assert math.isclose(mx_model.Consumer.use_elem(t), cross_elem[t] + 1.0)
+
+cross_whole = np.array([1.5, 2.5, 3.5])
+assert math.isclose(mx_model.Consumer.use_whole(), float(cross_whole.sum()))
+
+assert np.array_equal(
+    np.asarray(mx_model.Data.arr_external()), np.array([7.0, 8.0, 9.0]))

--- a/modelx_cython/tests/samples/array_usage/sample.py
+++ b/modelx_cython/tests/samples/array_usage/sample.py
@@ -1,0 +1,16 @@
+from ArrayUsage_nomx import mx_model
+
+for i in range(3):
+    mx_model.Data.elem(i)
+
+for i in range(2):
+    mx_model.Data.elem2d(i)
+
+mx_model.Data.whole_sum()
+mx_model.Data.sliced_prod()
+mx_model.Data.arr_external()
+
+for t in range(3):
+    mx_model.Consumer.use_elem(t)
+
+mx_model.Consumer.use_whole()

--- a/modelx_cython/tests/samples/array_usage/spec_bad_mv.py
+++ b/modelx_cython/tests/samples/array_usage/spec_bad_mv.py
@@ -1,0 +1,1 @@
+{"spaces": {"Data": {"cells": {"whole_sum": {"return_type": "memoryview"}}}}}

--- a/modelx_cython/tests/samples/array_usage/spec_force_mv.py
+++ b/modelx_cython/tests/samples/array_usage/spec_force_mv.py
@@ -1,0 +1,1 @@
+{"spaces": {"Data": {"cells": {"arr_whole": {"return_type": "memoryview"}}}}}

--- a/modelx_cython/tests/samples/basicterm_s/spec.py
+++ b/modelx_cython/tests/samples/basicterm_s/spec.py
@@ -1,3 +1,2 @@
 
-{"spaces": {"Projection": {"cells_params": {"t": {"size": 241}},
-                           "cells": {"disc_factors": {"return_type": "object"}}}}}
+{"spaces": {"Projection": {"cells_params": {"t": {"size": 241}}}}}

--- a/modelx_cython/tests/test_builder.py
+++ b/modelx_cython/tests/test_builder.py
@@ -1,0 +1,89 @@
+import types
+
+import numpy as np
+import pytest
+
+from modelx_cython.builder import (
+    CombinedCellsInfo,
+    MEMORYVIEW_FOR_EXTERNAL_ONLY_ARRAYS,
+)
+from modelx_cython.parser import LexicalCellsInfo
+from modelx_cython.tracer import ReturnTypeInfo
+from modelx_cython.usage import UsageVerdict
+
+FQ = "M._mx_classes._c_S._f_arr"
+
+
+def make_lx():
+    return LexicalCellsInfo("M._mx_classes", "_c_S", "arr", [])
+
+
+def make_cells(spec=None, usage=None, ndim=1, value_type=np.float64,
+               is_array=True):
+    rt = types.SimpleNamespace(
+        ret_type=ReturnTypeInfo(value_type, is_array=is_array, ndim=ndim),
+        arg_types={},
+    )
+    cells = CombinedCellsInfo(None, make_lx(), rt, spec or {})
+    if usage is not None:
+        cells.usage = usage
+    return cells
+
+
+def test_rettype_without_verdict_keeps_memoryview():
+    assert make_cells().get_rettype_expr(c_style=True) == "const double[:]"
+    assert make_cells(ndim=2).get_rettype_expr(c_style=True) \
+        == "const double[:, :]"
+    assert make_cells().get_rettype_expr() == "_mx_cy.const[_mx_cy.double][:]"
+
+
+def test_rettype_safe_verdict_keeps_memoryview():
+    cells = make_cells(usage=UsageVerdict(FQ, 1, True, True))
+    assert cells.get_rettype_expr(c_style=True) == "const double[:]"
+
+
+def test_rettype_unsafe_verdict_falls_back_to_object():
+    cells = make_cells(usage=UsageVerdict(FQ, 1, False, True))
+    assert cells.get_rettype_expr(c_style=True) == "object"
+
+
+def test_rettype_poisoned_verdict_falls_back_to_object():
+    # unresolvable call sites mark unsafe without marking internal uses;
+    # the unsafe flag must win over the no-internal-uses policy
+    cells = make_cells(usage=UsageVerdict(FQ, 1, False, False))
+    assert cells.get_rettype_expr(c_style=True) == "object"
+
+
+def test_rettype_no_internal_uses_follows_policy():
+    cells = make_cells(usage=UsageVerdict(FQ, 1, True, False))
+    expected = ("const double[:]" if MEMORYVIEW_FOR_EXTERNAL_ONLY_ARRAYS
+                else "object")
+    assert cells.get_rettype_expr(c_style=True) == expected
+
+
+def test_spec_memoryview_overrides_unsafe_verdict():
+    cells = make_cells(spec={"return_type": "memoryview"},
+                       usage=UsageVerdict(FQ, 1, False, True))
+    assert cells.get_rettype_expr(c_style=True) == "const double[:]"
+
+
+def test_spec_object_overrides_all():
+    cells = make_cells(spec={"return_type": "object"},
+                       usage=UsageVerdict(FQ, 1, True, True))
+    assert cells.get_rettype_expr(c_style=True) == "object"
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"is_array": False, "value_type": float},   # scalar return
+    {"ndim": 0},                                # 0-d array
+])
+def test_spec_memoryview_invalid_return_raises(kwargs):
+    with pytest.raises(ValueError,
+                       match="requires a real-valued numpy array return"):
+        make_cells(spec={"return_type": "memoryview"}, **kwargs)
+
+
+def test_spec_memoryview_without_typeinfo_ignored(caplog):
+    cells = CombinedCellsInfo(None, make_lx(), None,
+                              {"return_type": "memoryview"})
+    assert cells.get_rettype_expr(c_style=True) == "object"

--- a/modelx_cython/tests/test_cli.py
+++ b/modelx_cython/tests/test_cli.py
@@ -1,0 +1,22 @@
+from modelx_cython.cli import iter_module_files
+
+
+def test_iter_module_files(tmp_path):
+    root = tmp_path / "Model_nomx_cy"
+    (root / "_m_Sub" / "_m_Nested").mkdir(parents=True)
+    (root / "_mx_model.py").write_text("")
+    (root / "_mx_classes.py").write_text("")
+    (root / "_mx_sys.py").write_text("")    # not a model/space module
+    (root / "_m_Sub" / "_mx_classes.py").write_text("")
+    (root / "_m_Sub" / "_m_Nested" / "_mx_classes.py").write_text("")
+
+    found = dict(iter_module_files(root))
+
+    assert set(found) == {
+        "Model_nomx_cy._mx_model",
+        "Model_nomx_cy._mx_classes",
+        "Model_nomx_cy._m_Sub._mx_classes",
+        "Model_nomx_cy._m_Sub._m_Nested._mx_classes",
+    }
+    for fqname, path in found.items():
+        assert path.is_file()

--- a/modelx_cython/tests/test_samples.py
+++ b/modelx_cython/tests/test_samples.py
@@ -38,7 +38,13 @@ def test_mx2cy_with_lifelib(sample_dir, target, model):
     elif target == "main":
         from modelx_cython.cli import main
         assert main(argv[1:], sys.stdout, sys.stderr) == 0
-    
+
+    if model == "BasicTerm_S":
+        # the usage classifier detects disc_factors' whole-array consumers
+        # without a spec override
+        pxd = (work_dir / (model + "_nomx_cy") / "_mx_classes.pxd").read_text()
+        assert "cdef object _v_disc_factors\n" in pxd
+
     assert subprocess.run(
         [sys.executable, str(work_dir / "assert_cy.py")],
         env=env
@@ -206,6 +212,63 @@ def test_various_types(sample_dir, model, sample, assertion):
         capture_output=True,
         text=True
     ).returncode == 0
+
+
+@pytest.mark.parametrize("sample_dir, model", [["array_usage", "ArrayUsage"]],
+                         indirect=["sample_dir"])
+def test_array_usage(sample_dir, model):
+    """Memoryview return types are kept only for element-access-only cells"""
+    generate_nomx(work_dir := sample_dir, model)
+    env = get_env(work_dir)
+
+    argv = ["mx2cy", str(work_dir / (model + "_nomx")),
+            "--sample", str(work_dir / "sample.py"),
+            "--no-spec"]
+
+    assert subprocess.run(argv, env=env, cwd=work_dir).returncode == 0
+
+    pxd = (work_dir / (model + "_nomx_cy") / "_mx_classes.pxd").read_text()
+
+    # element-access-only consumers keep the memoryview
+    assert "cdef const double[:] _v_arr_elem\n" in pxd
+    assert "cdef const double[:, :] _v_arr2d\n" in pxd
+    assert "cdef const double[:] _v_arr_cross_elem\n" in pxd
+    assert "cpdef const double[:] arr_elem(_c_Data self)\n" in pxd
+
+    # whole-array consumers fall back to object
+    assert "cdef object _v_arr_whole\n" in pxd
+    assert "cdef object _v_arr_sliced\n" in pxd
+    assert "cdef object _v_arr_cross_whole\n" in pxd
+    assert "cpdef object arr_whole(_c_Data self)\n" in pxd
+
+    # no model-internal uses: the memoryview is kept (policy)
+    assert "cdef const double[:] _v_arr_external\n" in pxd
+
+    assert subprocess.run(
+        [sys.executable, str(work_dir / "assert_cy.py")],
+        env=env
+    ).returncode == 0
+
+    # spec return_type "memoryview" overrides the classifier
+    argv = ["mx2cy", str(work_dir / (model + "_nomx")),
+            "--sample", str(work_dir / "sample.py"),
+            "--spec", str(work_dir / "spec_force_mv.py"),
+            "--translate-only"]
+
+    assert subprocess.run(argv, env=env, cwd=work_dir).returncode == 0
+    pxd = (work_dir / (model + "_nomx_cy") / "_mx_classes.pxd").read_text()
+    assert "cdef const double[:] _v_arr_whole\n" in pxd
+
+    # "memoryview" on a cells not returning a real-valued array is an error
+    argv = ["mx2cy", str(work_dir / (model + "_nomx")),
+            "--sample", str(work_dir / "sample.py"),
+            "--spec", str(work_dir / "spec_bad_mv.py"),
+            "--translate-only"]
+
+    result = subprocess.run(argv, env=env, cwd=work_dir,
+                            capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "requires a real-valued numpy array return" in result.stderr
 
 
 @pytest.mark.parametrize("sample_dir, model", [["array_size", "ArraySize"]],

--- a/modelx_cython/tests/test_usage.py
+++ b/modelx_cython/tests/test_usage.py
@@ -1,0 +1,298 @@
+import libcst as cst
+import pytest
+
+from modelx_cython.usage import CellsResolver, UsageClassifier
+
+MOD = "M._mx_classes"
+CLS = MOD + "._c_S"
+ARR = CLS + "._f_arr"       # ndim-1 candidate
+MAT = CLS + "._f_mat"       # ndim-2 candidate
+USE = CLS + "._f_use"
+PROJ = CLS + "._f_proj_len"
+
+SRC_TMPL = """
+class _c_S:
+    def _f_use(self, t, i, j):
+        {body}
+"""
+
+
+def make_classifier(candidates=None, cells=None, refs=None, spaces=None,
+                    scalar_refs=None, array_returning=None):
+    resolver = CellsResolver(
+        cells if cells is not None else {
+            CLS: {"arr": ARR, "mat": MAT, "use": USE, "proj_len": PROJ}},
+        refs if refs is not None else {CLS: {"np": ""}},
+        spaces if spaces is not None else {},
+        scalar_refs,
+    )
+    return UsageClassifier(
+        candidates if candidates is not None else {ARR: 1, MAT: 2},
+        resolver,
+        array_returning,
+    )
+
+
+def classify(clf, source, module=MOD):
+    clf.classify_module(
+        module, cst.metadata.MetadataWrapper(cst.parse_module(source)))
+    return clf.result()
+
+
+def run(body, **kwargs):
+    return classify(make_classifier(**kwargs), SRC_TMPL.format(body=body))
+
+
+@pytest.mark.parametrize("body, key, safe", [
+    ("return self.arr()[t]", ARR, True),
+    ("self.arr()", ARR, True),      # bare statement, value discarded
+    ("return (1 + self.arr()[t])**(-t)", ARR, True),
+    ("return self.np.array(list((1 + self.arr()[t])**(-t)"
+     " for t in range(self.proj_len())))", ARR, True),
+    ("return sum(list(self.proj_len() for t in range(3))"
+     " * self.arr()[:self.proj_len()])", ARR, False),   # slice then operate
+    ("return self.mat()[i, j] + 1", MAT, True),
+    ("return self.mat()[i] * 2", MAT, False),           # partial index then op
+    ("return self.mat()[i][j]", MAT, True),             # chained completion
+    ("return self.mat()[0, :][j]", MAT, True),          # slice then scalar
+    ("return self.arr()[:3][t]", ARR, True),
+    ("return self.arr()[i, j]", ARR, False),            # over-indexing
+    ("return self.arr() * 2", ARR, False),
+    ("return len(self.arr())", ARR, False),
+    ("return self.arr()", ARR, False),                  # returned whole
+    ("return self.arr().mean()", ARR, False),
+    ("return [self.arr() for t in range(3)]", ARR, False),
+    ("return self.arr()[[0, 1]]", ARR, False),          # fancy index
+    ("return self.arr()[(0, 1)]", ARR, False),          # tuple index
+    ("x = self.arr()\n        return x[t]", ARR, False),  # aliased to local
+])
+def test_use_forms(body, key, safe):
+    verdict = run(body)[key]
+    assert verdict.only_element_access is safe
+    assert verdict.has_internal_uses
+    if not safe:
+        assert verdict.unsafe_sites
+
+
+def test_no_internal_uses():
+    verdicts = run("return 1")
+    for verdict in verdicts.values():
+        assert verdict.only_element_access
+        assert not verdict.has_internal_uses
+
+
+@pytest.mark.parametrize("body, key", [
+    ("self.arr()[t] = 1.0", ARR),
+    ("self.arr()[t] += 1.0", ARR),
+    ("del self.arr()[t]", ARR),
+    ("self.mat()[i, j] = 1.0", MAT),
+    ("self.mat()[i][j] = 1.0", MAT),
+    ("self.arr()[t], x = 1.0, 2.0", ARR),    # unpacking store
+])
+def test_element_store_unsafe(body, key):
+    # writing through the returned view needs a non-const object return
+    assert not run(body)[key].only_element_access
+
+
+def test_index_by_non_scalar_ref():
+    # a ref not sampled as a plain number may hold an index array
+    verdicts = run("return self.arr()[self.sel]", refs={CLS: {"sel": ""}})
+    assert not verdicts[ARR].only_element_access
+
+
+def test_index_by_scalar_ref_safe():
+    clf = make_classifier(refs={CLS: {"k": ""}}, scalar_refs={CLS: {"k"}})
+    verdicts = classify(clf, SRC_TMPL.format(body="return self.arr()[self.k]"))
+    assert verdicts[ARR].only_element_access
+
+
+@pytest.mark.parametrize("body", [
+    "return self.arr()[self._parent.pick()]",   # unresolvable call base
+    "return self.arr()[self.np.where(t)[0]]",   # module call may return arrays
+])
+def test_index_by_unresolvable_call(body):
+    assert not run(body)[ARR].only_element_access
+
+
+def test_slice_bound_array_call_unsafe():
+    body = "return self.arr()[:self.mat()][t]"
+    assert not run(body)[ARR].only_element_access
+
+
+def test_non_candidate_array_cells_as_index():
+    # cells outside the candidate set (e.g. int arrays) still count as
+    # array-returning when used as an index
+    idx = CLS + "._f_idx"
+    cells = {CLS: {"mat": MAT, "idx": idx}}
+    body = SRC_TMPL.format(body="return self.mat()[self.idx(), 0]")
+
+    unsafe = classify(make_classifier(
+        candidates={MAT: 2}, cells=cells, array_returning={MAT, idx}), body)
+    assert not unsafe[MAT].only_element_access
+
+    safe = classify(make_classifier(
+        candidates={MAT: 2}, cells=cells, array_returning={MAT}), body)
+    assert safe[MAT].only_element_access
+
+
+A_CLS = "M._mx_classes._c_A"
+B_CLS = "N._m_X._mx_classes._c_B"
+ARR2 = B_CLS + "._f_arr2"
+
+CROSS_TMPL = """
+class _c_A:
+    def _f_use(self, t):
+        {body}
+"""
+
+
+def run_cross(body, refs=None, spaces=None):
+    clf = UsageClassifier(
+        {ARR2: 1},
+        CellsResolver(
+            {A_CLS: {"use": A_CLS + "._f_use"}, B_CLS: {"arr2": ARR2}},
+            refs if refs is not None else {A_CLS: {"data": B_CLS}},
+            spaces if spaces is not None else {},
+        ),
+    )
+    return classify(clf, CROSS_TMPL.format(body=body))
+
+
+def test_cross_space_ref_safe():
+    verdict = run_cross("return self.data.arr2()[t]")[ARR2]
+    assert verdict.only_element_access and verdict.has_internal_uses
+
+
+def test_cross_space_ref_unsafe():
+    assert not run_cross("return self.data.arr2() * 2")[ARR2].only_element_access
+
+
+def test_cross_space_three_level_chain():
+    # self.<ref to Bar>.<child space Qux>.<cells>, as in the ref_space sample
+    bar_cls = "M._mx_classes._c_Bar"
+    refs = {A_CLS: {"bar": bar_cls}}
+    spaces = {bar_cls: {"Qux": B_CLS}}
+    clf = UsageClassifier(
+        {ARR2: 1},
+        CellsResolver(
+            {A_CLS: {}, bar_cls: {}, B_CLS: {"arr2": ARR2}},
+            refs, spaces,
+        ),
+    )
+    verdict = classify(clf, CROSS_TMPL.format(
+        body="return self.bar.Qux.arr2()[t]"))[ARR2]
+    assert verdict.only_element_access and verdict.has_internal_uses
+
+
+def test_np_ref_ignored():
+    # a cells named like a numpy method must not be poisoned by self.np calls
+    array_cells = CLS + "._f_array"
+    verdicts = run(
+        "return self.np.array([1])",
+        candidates={array_cells: 1},
+        cells={CLS: {"array": array_cells}},
+    )
+    assert verdicts[array_cells].only_element_access
+    assert not verdicts[array_cells].has_internal_uses
+
+
+@pytest.mark.parametrize("body", [
+    "return self._parent.arr()[t]",     # unknown attribute base
+    "return sp.arr()[t]",               # non-self name base
+])
+def test_unresolvable_base_poisons(body):
+    verdict = run(body)[ARR]
+    assert not verdict.only_element_access
+    assert verdict.unsafe_sites
+
+
+def test_unresolvable_base_without_matching_cells():
+    verdicts = run("return self._parent.nothing()")
+    assert all(v.only_element_access for v in verdicts.values())
+
+
+def test_poison_reaches_other_class():
+    # an alias in one class poisons a same-named candidate in another class
+    clf = UsageClassifier(
+        {ARR2: 1},
+        CellsResolver(
+            {A_CLS: {"use": A_CLS + "._f_use"}, B_CLS: {"arr2": ARR2}},
+            {A_CLS: {"data": B_CLS}},
+            {},
+        ),
+    )
+    src = CROSS_TMPL.format(body="d = self.data\n        return d.arr2().sum()")
+    assert not classify(clf, src)[ARR2].only_element_access
+
+
+def test_unparsed_child_space_poisons():
+    # a child space whose module was not parsed cannot vouch for the call
+    clf = UsageClassifier(
+        {ARR2: 1},
+        CellsResolver(
+            {A_CLS: {}, B_CLS: {"arr2": ARR2}},
+            {},
+            {A_CLS: {"Child": "M._m_A._mx_classes._c_Child"}},
+        ),
+    )
+    src = CROSS_TMPL.format(body="return self.Child.arr2()[t]")
+    assert not classify(clf, src)[ARR2].only_element_access
+
+
+def test_unparsed_ref_class_poisons():
+    # a space-typed ref whose class module was not parsed poisons by name
+    clf = UsageClassifier(
+        {ARR2: 1},
+        CellsResolver(
+            {A_CLS: {}, B_CLS: {"arr2": ARR2}},
+            {A_CLS: {"data": "Unparsed._mx_classes._c_X"}},
+            {},
+        ),
+    )
+    src = CROSS_TMPL.format(body="return self.data.arr2()[t]")
+    assert not classify(clf, src)[ARR2].only_element_access
+
+
+def test_array_valued_index():
+    verdicts = run("return self.mat()[self.arr(), 0]")
+    assert not verdicts[MAT].only_element_access   # fancy index by an array
+    assert not verdicts[ARR].only_element_access   # used as an index array
+
+
+def test_aggregation_across_modules():
+    safe_src = CROSS_TMPL.format(body="return self.data.arr2()[t]")
+    unsafe_src = CROSS_TMPL.format(body="return self.data.arr2().sum()")
+
+    for sources in ([safe_src, unsafe_src], [unsafe_src, safe_src]):
+        clf = UsageClassifier(
+            {ARR2: 1},
+            CellsResolver(
+                {A_CLS: {"use": A_CLS + "._f_use"}, B_CLS: {"arr2": ARR2}},
+                {A_CLS: {"data": B_CLS}},
+                {},
+            ),
+        )
+        for src in sources:
+            classify(clf, src)
+        assert not clf.result()[ARR2].only_element_access
+
+
+def test_non_space_class_ignored():
+    src = """
+class Helper:
+    def _f_use(self, t):
+        return self.arr() * 2
+"""
+    verdicts = classify(make_classifier(), src)
+    assert verdicts[ARR].only_element_access
+    assert not verdicts[ARR].has_internal_uses
+
+
+def test_wrapper_revisited_twice():
+    # the production pass re-visits the parser's MetadataWrapper
+    wrapper = cst.metadata.MetadataWrapper(
+        cst.parse_module(SRC_TMPL.format(body="return self.arr() * 2")))
+    for _ in range(2):
+        clf = make_classifier()
+        clf.classify_module(MOD, wrapper)
+        assert not clf.result()[ARR].only_element_access

--- a/modelx_cython/usage.py
+++ b/modelx_cython/usage.py
@@ -1,0 +1,489 @@
+# Copyright (c) 2023-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Static classification of how cells return values are used.
+
+A cells whose sampled return value is a real-valued numpy array is a
+candidate for a typed memoryview return type. A memoryview, however,
+supports only element access; consumers that operate on the whole array
+(arithmetic, numpy methods, passing to functions) need the value as an
+object. This module walks every module's CST and checks, for each
+candidate cells, whether all of its model-internal call sites use the
+returned value only through element subscripting. Cells that fail the
+check fall back to an object return type in the builder.
+
+The classification is conservative: any use that cannot be proven to be
+element access counts as unsafe, and call sites that cannot be resolved
+to a cells poison every cells with a matching name.
+"""
+
+from dataclasses import dataclass, field
+import logging
+import numbers
+from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.metadata import (
+    GlobalScope,
+    ParentNodeProvider,
+    PositionProvider,
+    ScopeProvider,
+)
+
+from modelx_cython.consts import (
+    MODULE_PREF,
+    MX_MODEL_MOD,
+    MX_SPACE_MOD,
+    MX_SELF,
+    SPACE_PREF,
+)
+from modelx_cython.parser import ParentScopeAddin
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UsageVerdict:
+    """Aggregated classification of one candidate cells' call sites."""
+
+    fqname: str
+    ndim: int
+    only_element_access: bool = True
+    has_internal_uses: bool = False
+    unsafe_sites: List[str] = field(default_factory=list)
+
+
+# resolve_chain result kinds
+RESOLVED = "resolved"
+NOT_CELLS = "not_cells"
+UNKNOWN = "unknown"
+
+
+class CellsResolver:
+    """Resolves self-rooted attribute chains to cells across the whole model.
+
+    All three mappings are keyed by class fqname (``<module>.<cls>``):
+
+    * ``cells_by_class``: public cells name -> cells fqname
+    * ``refs_by_class``: ref or space-param name -> mx_class fqname of the
+      space the ref holds, or "" for non-space refs (modules, tables, scalars)
+    * ``spaces_by_class``: child space attribute name -> child class fqname
+    * ``scalar_refs_by_class``: names of refs whose sampled values are plain
+      numbers, i.e. provably safe to use as subscript indices
+    """
+
+    def __init__(
+        self,
+        cells_by_class: Mapping[str, Mapping[str, str]],
+        refs_by_class: Mapping[str, Mapping[str, str]],
+        spaces_by_class: Mapping[str, Mapping[str, str]],
+        scalar_refs_by_class: Optional[Mapping[str, Set[str]]] = None,
+    ) -> None:
+        self._cells = cells_by_class
+        self._refs = refs_by_class
+        self._spaces = spaces_by_class
+        self._scalar_refs = scalar_refs_by_class or {}
+        self._name_index: Dict[str, List[str]] = {}
+        for cells in cells_by_class.values():
+            for name, fqname in cells.items():
+                self._name_index.setdefault(name, []).append(fqname)
+
+    def resolve_chain(
+        self, cls_fqname: str, chain: Sequence[str]
+    ) -> Tuple[str, str]:
+        cur = cls_fqname
+        for attr in chain[:-1]:
+            child = self._spaces.get(cur, {}).get(attr, "")
+            if child:
+                if child in self._cells:
+                    cur = child
+                    continue
+                return UNKNOWN, chain[-1]   # child module not parsed
+            refs = self._refs.get(cur, {})
+            if attr in refs:
+                mx_class = refs[attr]
+                if not mx_class:
+                    return NOT_CELLS, ""    # non-space ref (np, tables, params)
+                if mx_class in self._cells:
+                    cur = mx_class
+                    continue
+                return UNKNOWN, chain[-1]   # space class not among parsed modules
+            return UNKNOWN, chain[-1]       # _parent and other untracked attributes
+        name = chain[-1]
+        fqname = self._cells.get(cur, {}).get(name, "")
+        if fqname:
+            return RESOLVED, fqname
+        return NOT_CELLS, ""                # itemspace call, non-cells attribute
+
+    def is_scalar_ref(self, cls_fqname: str, chain: Sequence[str]) -> bool:
+        """Whether a non-call attribute chain rooted at self names a ref
+        whose sampled value is a plain number."""
+        cur = cls_fqname
+        for attr in chain[:-1]:
+            child = self._spaces.get(cur, {}).get(attr, "")
+            if child and child in self._cells:
+                cur = child
+                continue
+            mx_class = self._refs.get(cur, {}).get(attr, "")
+            if mx_class and mx_class in self._cells:
+                cur = mx_class
+                continue
+            return False
+        return chain[-1] in self._scalar_refs.get(cur, set())
+
+    def cells_with_name(self, name: str) -> Sequence[str]:
+        return self._name_index.get(name, ())
+
+
+class _Unresolved:
+    """Call whose base is not a self-rooted attribute chain."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _extract_self_chain(
+    func: cst.BaseExpression,
+) -> Union[List[str], _Unresolved, None]:
+    """["bar", "Qux", "qux"] for self.bar.Qux.qux; _Unresolved(called name)
+    for attribute chains not rooted at self; None for non-attribute callees."""
+    if not isinstance(func, cst.Attribute):
+        return None
+    names = []
+    node: cst.BaseExpression = func
+    while isinstance(node, cst.Attribute):
+        names.append(node.attr.value)
+        node = node.value
+    if isinstance(node, cst.Name) and node.value == MX_SELF:
+        names.reverse()
+        return names
+    return _Unresolved(names[0])
+
+
+class UsageClassifier:
+    """Classifies call sites of candidate cells over one or more modules.
+
+    ``candidates`` maps each candidate cells fqname to the ndim of its
+    returned array. ``array_returning`` holds the fqnames of all
+    array-returning cells of any dtype (used to reject array-valued index
+    expressions); it defaults to the candidate set.
+    """
+
+    _FANCY_INDEX_NODES = (
+        cst.Tuple,
+        cst.List,
+        cst.Set,
+        cst.Dict,
+        cst.Comparison,
+        cst.BooleanOperation,
+        cst.Ellipsis,
+    )
+
+    def __init__(
+        self,
+        candidates: Mapping[str, int],
+        resolver: CellsResolver,
+        array_returning: Optional[Set[str]] = None,
+    ) -> None:
+        self._resolver = resolver
+        self._array_returning = (
+            set(candidates) if array_returning is None else array_returning
+        )
+        self.verdicts: Dict[str, UsageVerdict] = {
+            fqname: UsageVerdict(fqname, ndim)
+            for fqname, ndim in candidates.items()
+        }
+
+    def classify_module(
+        self, module_fqname: str, wrapper: cst.metadata.MetadataWrapper
+    ) -> None:
+        wrapper.visit(UsageVisitor(module_fqname, self))
+
+    def result(self) -> Dict[str, UsageVerdict]:
+        return self.verdicts
+
+    # Called by UsageVisitor
+
+    def handle_call(
+        self, visitor: "UsageVisitor", cls_fqname: str, node: cst.Call
+    ) -> None:
+        chain = _extract_self_chain(node.func)
+        if chain is None:
+            return
+        if isinstance(chain, _Unresolved):
+            self._poison(visitor, node, chain.name, "unresolvable call base")
+            return
+        kind, payload = self._resolver.resolve_chain(cls_fqname, chain)
+        if kind == NOT_CELLS:
+            return
+        elif kind == UNKNOWN:
+            self._poison(visitor, node, payload, "unresolvable reference chain")
+            return
+        verdict = self.verdicts.get(payload)
+        if verdict is None:
+            return      # not a candidate
+        verdict.has_internal_uses = True
+        safe, reason = self._classify_use(visitor, cls_fqname, node, verdict.ndim)
+        if not safe:
+            self._mark_unsafe(visitor, node, verdict, reason)
+
+    def _poison(
+        self, visitor: "UsageVisitor", node: cst.Call, name: str, reason: str
+    ) -> None:
+        for fqname in self._resolver.cells_with_name(name):
+            verdict = self.verdicts.get(fqname)
+            if verdict is not None:
+                self._mark_unsafe(visitor, node, verdict, reason)
+
+    def _mark_unsafe(
+        self,
+        visitor: "UsageVisitor",
+        node: cst.Call,
+        verdict: UsageVerdict,
+        reason: str,
+    ) -> None:
+        verdict.only_element_access = False
+        line = visitor.get_metadata(PositionProvider, node).start.line
+        verdict.unsafe_sites.append(f"{visitor.module}:{line} {reason}")
+
+    def _classify_use(
+        self,
+        visitor: "UsageVisitor",
+        cls_fqname: str,
+        node: cst.Call,
+        ndim: int,
+    ) -> Tuple[bool, str]:
+        """Walk up from a candidate call until the value is proven to be
+        consumed as a scalar element (safe) or anything else (unsafe)."""
+        current: cst.BaseExpression = node
+        remaining = ndim
+        while True:
+            parent = visitor.get_parent(current, level=1)
+            if isinstance(parent, cst.Subscript) and parent.value is current:
+                n_index = n_slice = 0
+                for element in parent.slice:
+                    sl = element.slice
+                    if isinstance(sl, cst.Index):
+                        if not self._is_element_index(cls_fqname, sl.value):
+                            return False, "non-scalar index expression"
+                        n_index += 1
+                    elif isinstance(sl, cst.Slice):
+                        for bound in (sl.lower, sl.upper, sl.step):
+                            if bound is not None and not self._is_element_index(
+                                    cls_fqname, bound):
+                                return False, "non-scalar slice bound"
+                        n_slice += 1
+                    else:
+                        return False, "unsupported subscript element"
+                if n_index + n_slice > remaining:
+                    return False, "too many subscript indices"
+                if n_slice == 0 and n_index == remaining:
+                    if self._is_store_target(visitor, parent):
+                        return False, "element store target"
+                    return True, ""     # scalar element access
+                remaining -= n_index    # the result is still a memoryview
+                current = parent
+            elif isinstance(parent, cst.Expr):
+                return True, ""         # value discarded
+            else:
+                return False, f"used as {type(parent).__name__}"
+
+    @staticmethod
+    def _is_store_target(visitor: "UsageVisitor", node: cst.CSTNode) -> bool:
+        """Whether the completed subscript is written to or deleted, as in
+        'self.arr()[t] = v', '+=', 'del self.arr()[t]' or unpacking."""
+        parent = visitor.get_parent(node, level=1)
+        while isinstance(
+                parent, (cst.Element, cst.Tuple, cst.List, cst.StarredElement)):
+            node = parent
+            parent = visitor.get_parent(node, level=1)
+        if isinstance(parent, (cst.AssignTarget, cst.Del)):
+            return True
+        if isinstance(parent, (cst.AugAssign, cst.AnnAssign)):
+            return parent.target is node
+        return False
+
+    def _is_element_index(
+        self, cls_fqname: str, expr: cst.BaseExpression
+    ) -> bool:
+        """Reject index and slice-bound expressions that may select more
+        than one element: fancy-indexing literals, newaxis, calls to
+        array-returning or unresolvable cells, and refs not sampled as
+        plain numbers. Bare names (parameters, locals) and bare-name calls
+        (max, int, ...) are assumed to be scalars."""
+        if isinstance(expr, self._FANCY_INDEX_NODES):
+            return False
+        if isinstance(expr, cst.Name) and expr.value == "None":
+            return False
+        scanner = _IndexExprScanner(self, cls_fqname)
+        expr.visit(scanner)
+        return not scanner.unsafe
+
+
+class _IndexExprScanner(cst.CSTVisitor):
+    """Scans an index or slice-bound expression for subexpressions that may
+    produce arrays rather than scalars. Calls and attribute chains are
+    classified at their outermost node and then pruned; nested calls are
+    still classified independently by the module-wide pass."""
+
+    def __init__(self, classifier: "UsageClassifier", cls_fqname: str) -> None:
+        super().__init__()
+        self._clf = classifier
+        self._cls = cls_fqname
+        self.unsafe = False
+
+    def visit_Call(self, node: cst.Call) -> bool:
+        chain = _extract_self_chain(node.func)
+        if chain is None:
+            return True     # bare-name call (max, int, ...): scan its args
+        if isinstance(chain, _Unresolved):
+            self.unsafe = True
+            return False
+        kind, payload = self._clf._resolver.resolve_chain(self._cls, chain)
+        if kind == RESOLVED:
+            if payload in self._clf._array_returning:
+                self.unsafe = True
+        else:
+            # UNKNOWN bases and NOT_CELLS module functions (np.where, ...)
+            # may produce arrays
+            self.unsafe = True
+        return False
+
+    def visit_Attribute(self, node: cst.Attribute) -> bool:
+        chain = _extract_self_chain(node)
+        if not (isinstance(chain, list)
+                and self._clf._resolver.is_scalar_ref(self._cls, chain)):
+            self.unsafe = True
+        return False
+
+
+class UsageVisitor(cst.CSTVisitor, ParentScopeAddin):
+    METADATA_DEPENDENCIES = (ScopeProvider, ParentNodeProvider, PositionProvider)
+
+    def __init__(self, module: str, classifier: UsageClassifier) -> None:
+        super().__init__()
+        self.module = module
+        self._classifier = classifier
+        self._cls_stack: List[str] = []
+
+    def visit_ClassDef(self, node: cst.ClassDef) -> bool:
+        name = node.name.value
+        if (
+            name[: len(SPACE_PREF)] == SPACE_PREF
+            and isinstance(self.get_metadata(ScopeProvider, node), GlobalScope)
+        ):
+            self._cls_stack.append(self.module + "." + name)
+        else:
+            self._cls_stack.append("")
+        return True
+
+    def leave_ClassDef(self, original_node: cst.ClassDef) -> None:
+        self._cls_stack.pop()
+
+    def visit_Call(self, node: cst.Call) -> bool:
+        if self._cls_stack and self._cls_stack[-1]:
+            self._classifier.handle_call(self, self._cls_stack[-1], node)
+        return True
+
+
+# Wrappers connecting the classifier to builder objects
+
+
+def collect_candidates(module_infos) -> Tuple[Dict[str, int], Set[str]]:
+    """Memoryview candidates ({fqname: ndim}) and all array-returning
+    cells fqnames, over {fqname: ModuleInfo}. Cells with an explicit spec
+    return_type are not candidates: the spec wins in both directions."""
+    candidates: Dict[str, int] = {}
+    array_returning: Set[str] = set()
+    for info in module_infos.values():
+        for cls_info in info.classes.values():
+            for cells in cls_info.cells.values():
+                if not cells.has_typeinfo() or not cells.is_array_returned:
+                    continue
+                array_returning.add(cells.fqname)
+                if (
+                    not cells.has_spec_rettype
+                    and not cells.is_special()
+                    and cells.is_real_value
+                    and cells.ret_ndim >= 1
+                ):
+                    candidates[cells.fqname] = cells.ret_ndim
+    return candidates, array_returning
+
+
+def build_resolver(module_infos) -> CellsResolver:
+    cells_by_class: Dict[str, Dict[str, str]] = {}
+    refs_by_class: Dict[str, Dict[str, str]] = {}
+    spaces_by_class: Dict[str, Dict[str, str]] = {}
+    scalar_refs_by_class: Dict[str, Set[str]] = {}
+
+    for fqname, info in module_infos.items():
+        pkg, basename = fqname.rsplit(".", 1)
+        for cls_name, cls_info in info.classes.items():
+            cells_by_class[cls_info.fqname] = {
+                name: cells.fqname for name, cells in cls_info.cells.items()
+            }
+            refs_by_class[cls_info.fqname] = {
+                name: (ref.mx_class or "")
+                for name, ref in cls_info.refs.items()
+            }
+            scalar_refs_by_class[cls_info.fqname] = {
+                name for name, ref in cls_info.refs.items()
+                if ref.type_ is not None
+                and issubclass(ref.type_, numbers.Number)
+            }
+            if basename == MX_MODEL_MOD:
+                child_pkg = pkg     # model children live in <pkg>._mx_classes
+            else:
+                child_pkg = pkg + "." + MODULE_PREF + cls_name[len(SPACE_PREF):]
+            child_mod = child_pkg + "." + MX_SPACE_MOD
+            spaces_by_class[cls_info.fqname] = {
+                attr: child_mod + "." + SPACE_PREF + attr
+                for attr in cls_info.spaces
+            }
+    return CellsResolver(cells_by_class, refs_by_class, spaces_by_class,
+                         scalar_refs_by_class)
+
+
+def analyze_usage(units) -> Dict[str, UsageVerdict]:
+    """Classify all candidate cells over (ModuleVisitor, ModuleInfo) pairs."""
+    module_infos = {info.fqname: info for _, info in units}
+    candidates, array_returning = collect_candidates(module_infos)
+    if not candidates:
+        return {}
+    classifier = UsageClassifier(
+        candidates, build_resolver(module_infos), array_returning
+    )
+    for visitor, info in units:
+        classifier.classify_module(info.fqname, visitor.wrapper)
+    return classifier.result()
+
+
+def apply_verdicts(units, verdicts: Mapping[str, UsageVerdict]) -> None:
+    if not verdicts:
+        return
+    for _, info in units:
+        for cls_info in info.classes.values():
+            for cells in cls_info.cells.values():
+                verdict = verdicts.get(cells.fqname)
+                if verdict is not None:
+                    cells.usage = verdict
+                    if not verdict.only_element_access:
+                        _logger.info(
+                            f"return type of {cells.fqname} falls back to "
+                            "object: " + "; ".join(verdict.unsafe_sites[:3])
+                        )


### PR DESCRIPTION
## What

Adds a static usage-classification pass that decides, per array-returning cells, whether to emit a `const` memoryview return type or fall back to `object`. A memoryview is emitted only when every model-internal use of the cells' value is provably scalar element access; everything else demotes the return type to `object`, so the generated Cython always compiles and runs.

## Why

Formula bodies are emitted verbatim, so a consumer doing whole-array operations on a memoryview-typed value breaks the build (e.g. CashValue_ME's `pv_net_cf` adding six `double[:]` returns) or fails at runtime (`list * disc_factors()[:proj_len()]` in BasicTerm_S). The only remedy was a hand-written `"return_type": "object"` override in the spec file — this PR derives that decision automatically. The basicterm_s test now passes with its `disc_factors` override removed, and a pxd assertion locks in the derived `object` type.

## How

- **`modelx_cython/usage.py`** (new): `CellsResolver` resolves `self.cells()`, `self.<ref>.cells()` (via runtime-traced `mx_class`), and multi-level child-space chains model-wide. `UsageClassifier` walks up from each candidate call through subscripts (tracking remaining `ndim`, slices keep memoryview-ness) until the value is proven scalar or the use is rejected. Conservative rules: aliasing, whole-array ops, function arguments, element stores (`x[t] = v`, `+=`, `del`), fancy/array-valued indices, and unvalidated slice bounds are unsafe; unresolvable call bases poison all same-named cells. Index expressions stay permissive for bare names and builtin calls (so `mort_table_array()[age(t), max(min(5, d), 0)]` keeps its memoryview); refs are accepted as indices only when sampled as plain numbers.
- **`cli.py`**: the per-module loop is split into parse-all → classify → transform-all. Modules the sample never traced are parsed for the analysis (not transformed) so their consumption of traced cells is visible.
- **`builder.py`**: single gate in `get_rettype_expr` via a new `use_memoryview` property — all emission sites (pxd cache vars, `cdef`/`cpdef` declarations, annotations) change consistently. Cells with no model-internal call sites keep the memoryview (`MEMORYVIEW_FOR_EXTERNAL_ONLY_ARRAYS = True`, single flip point).
- **Spec**: `"return_type": "memoryview"` is a new escape hatch forcing memoryview emission past the classifier (validated: requires a sampled real-valued array with `ndim >= 1`); the existing `"object"` override still wins.

## Reviewer notes

- The classifier is deliberately conservative: a misclassification can only lose an optimization, never produce a broken build. Numpy calls that would work through the buffer protocol (`np.isclose(x, mv)`) still demote — a whitelist is a possible follow-up.
- An adversarial multi-agent review of the initial implementation confirmed and led to fixes for: element-store subscripts classified safe, sample-untraced modules being invisible to the analysis, and index/slice-bound blind spots (array-valued refs, unresolvable calls).
- New coverage: 26 classifier unit tests (`test_usage.py`), direct state-table tests of the builder gate (`test_builder.py`), module enumeration (`test_cli.py`), and an `array_usage` end-to-end sample that compiles and numerically validates mixed memoryview/object typing plus both spec-override paths.
- Full suite: 83 passed, 7 skipped (pre-existing skipped `main`-target params), including both lifelib-based basicterm tests with real Cython builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)