### PR TITLE
Support lifelib annuallife models and add TradLife_A / TradLife_A_EX1 tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ pytest                                                    # All tests (2-5 min)
 pytest modelx_cython/tests/test_config.py -v             # Config tests (<1s)
 pytest modelx_cython/tests/test_samples.py::test_no_spec -v  # Specific (5-15s)
 ```
-**Requires**: `lifelib` for integration tests | **Structure**: Unit tests in `test_config.py`, integration in `test_samples.py` (15 scenarios in `tests/samples/`)
+**Requires**: `lifelib` for integration tests | **Structure**: Unit tests in `test_config.py`, integration in `test_samples.py` and `test_annuallife.py` (16 scenarios in `tests/samples/`)
 
 ## Repository Structure
 
@@ -40,7 +40,7 @@ pytest modelx_cython/tests/test_samples.py::test_no_spec -v  # Specific (5-15s)
 **Main Package** (`modelx_cython/`) - Data flow order:
 1. `cli.py` - Entry point (`mx2cy` command) | 2. `tracer.py` - Runtime type collection (MonkeyType) | 3. `parser.py` - Parse models (libcst) | 4. `builder.py` - Combine parse/trace info | 5. `transformer.py` - Python→Cython transformation | 6. `config.py` - Config/spec handling | 7. `typedefs.py` - Type helpers | 8. `consts.py` - Constants/naming | 9. `monkeytype_tracing.py` - Custom tracer | 10. `_mx_sys.pxd` - Cython declarations | 11. `__init__.py` - Version (version_info tuple)
 
-**Tests** (`modelx_cython/tests/`): `test_config.py` (unit), `test_samples.py` (integration, parameterized), `samples/` (13 scenarios: array_size, basicterm_s, basicterm_sc, deep_recursion, duplicated_params, index_range, nested_params, no_spec, ref_space, size_spec_change, various_types, varying_integral_types_of_args, varying_types_of_args)
+**Tests** (`modelx_cython/tests/`): `test_config.py` (unit), `test_samples.py` and `test_annuallife.py` (integration, parameterized), `samples/` (16 scenarios: array_size, array_usage, basicterm_s, basicterm_sc, deep_recursion, duplicated_params, index_range, nested_params, no_spec, ref_space, size_spec_change, tradlife_a, tradlife_a_ex1, various_types, varying_integral_types_of_args, varying_types_of_args)
 
 ## Workflow & Usage
 

--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -31,6 +31,7 @@ from modelx_cython.tracer import RuntimeCellsInfo, MxCallTraceLogger
 from modelx_cython.parser import ModuleVisitor, LexicalCellsInfo, LexicalRefInfo
 
 from modelx_cython.consts import (
+    FORMULA_PREF,
     SPACE_PREF,
     MODULE_PREF,
     CY_MOD
@@ -65,8 +66,20 @@ class CombinedCellsInfo(LexicalCellsInfo):
             # their public method is the formula itself.
             self.has_formula_def = lx_info.name in visitor.formula_defs.get(
                 lx_info.cls, ())
+            # Closures (nested defs, lambdas, generator expressions, yield)
+            # cannot be compiled inside cpdef (ccall) functions, so public
+            # methods containing them are left as plain Python methods and
+            # omitted from the pxd. cdef (cfunc) formula methods support
+            # closures but not yield.
+            self.body_has_closure = lx_info.name in visitor.closure_funcs.get(
+                lx_info.cls, ())
+            self.formula_is_generator = (
+                FORMULA_PREF + lx_info.name
+                in visitor.generator_funcs.get(lx_info.cls, ()))
         else:   # constructed without a ClassInfo (tests)
             self.has_formula_def = True
+            self.formula_is_generator = False
+            self.body_has_closure = False
         self._rt = rt_info
         self._spec = spec
         self._spec_ret_t = spec.get(TransSpec.RET_T, "")

--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -280,6 +280,7 @@ class ClassInfo:
                         if v > d[k]:
                             d[k] = v
                             self._max_arg_cells[args][k] = lx_info.fqname
+                    self._cells_max_args[args] = tuple(d.values())
 
     def _init_spaces(self):
         self.spaces.extend(self.visitor.spaces.get(self.name, []))

--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -58,6 +58,15 @@ class CombinedCellsInfo(LexicalCellsInfo):
             lx_info.module, lx_info.cls, lx_info.name, lx_info.params
         )
         self.parent = cls_info
+        visitor = getattr(cls_info, "visitor", None)
+        if visitor is not None:
+            # True if a _f_<name> formula method exists in the source.
+            # Cells that modelx exports as uncached have no _f_ method:
+            # their public method is the formula itself.
+            self.has_formula_def = lx_info.name in visitor.formula_defs.get(
+                lx_info.cls, ())
+        else:   # constructed without a ClassInfo (tests)
+            self.has_formula_def = True
         self._rt = rt_info
         self._spec = spec
         self._spec_ret_t = spec.get(TransSpec.RET_T, "")

--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -227,6 +227,8 @@ class CombinedRefInfo:
     def get_type_expr(self, c_style=False):
         if self.decl_type_expr:
             return self.decl_type_expr
+        elif self.type_ is None:    # no runtime info sampled
+            return "object"
         else:
             return get_type_expr(self.type_, c_style=c_style)
 

--- a/modelx_cython/builder.py
+++ b/modelx_cython/builder.py
@@ -53,10 +53,14 @@ class CombinedCellsInfo(LexicalCellsInfo):
     _spec: dict
     _spec_ret_t: str
     usage: 'Optional[UsageVerdict]' = None  # set by usage.apply_verdicts
+    # True if some formula calls this cells with keyword arguments, which
+    # C-level (cpdef) calls do not support; set in cli.main_handler
+    called_with_kwargs: bool = False
 
     def __init__(self, cls_info, lx_info, rt_info, spec) -> None:
         super().__init__(
-            lx_info.module, lx_info.cls, lx_info.name, lx_info.params
+            lx_info.module, lx_info.cls, lx_info.name, lx_info.params,
+            lx_info.params_with_defaults
         )
         self.parent = cls_info
         visitor = getattr(cls_info, "visitor", None)

--- a/modelx_cython/cli.py
+++ b/modelx_cython/cli.py
@@ -119,7 +119,7 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
             d = {}
         else:
             try:
-                d = ast.literal_eval(pathlib.Path(args.spec).read_text())
+                d = ast.literal_eval(pathlib.Path(args.spec).read_text(encoding="utf-8"))
             except FileNotFoundError as e:
                 raise FileNotFoundError(f"{e}. Add '--no-spec' to omit the spec file.") from e
 
@@ -141,7 +141,7 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
             rel_src_path = rel_model_path / "/".join(subs)
             abs_pxd_path = model_path / "/".join(pxd_path)
             abs_init_path = model_path / "/".join(subs[:-1] + ["__init__.pxd"])
-            source = abs_src_path.read_text()
+            source = abs_src_path.read_text(encoding="utf-8")
             visitor = ModuleVisitor(module=m, source=source)
             module_info = ModuleInfo(m, visitor, logger, spec)
             units.append(_TransUnit(
@@ -157,7 +157,7 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
         traced = {u.fqname for u in units}
         for m, src_path in iter_module_files(model_path):
             if m not in traced:
-                visitor = ModuleVisitor(module=m, source=src_path.read_text())
+                visitor = ModuleVisitor(module=m, source=src_path.read_text(encoding="utf-8"))
                 pairs.append((visitor, ModuleInfo(m, visitor, logger, spec)))
         apply_verdicts(pairs, analyze_usage(pairs))
 
@@ -166,9 +166,9 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
             trans = ModuleTransformer(u.source, u.module_info)
             pxd = PXDGenerator(u.module_info)
 
-            u.abs_src_path.write_text(trans.transformed.code)
-            u.abs_pxd_path.write_text(pxd.code)
-            u.abs_init_path.write_text("from . cimport _mx_classes")
+            u.abs_src_path.write_text(trans.transformed.code, encoding="utf-8")
+            u.abs_pxd_path.write_text(pxd.code, encoding="utf-8")
+            u.abs_init_path.write_text("from . cimport _mx_classes", encoding="utf-8")
             modules.append(u.rel_src_path)
 
         create_setup(model_name, modules=modules, setup_file=setup_file)
@@ -317,7 +317,8 @@ def create_setup(model_name: str, modules: Sequence[str], setup_file: pathlib.Pa
     setup_file.write_text(
         setup_script.format(
             model_name=model_name,
-            modules_str=modules_str))
+            modules_str=modules_str),
+        encoding="utf-8")
 
 
 def entry_point_main():

--- a/modelx_cython/cli.py
+++ b/modelx_cython/cli.py
@@ -33,6 +33,8 @@ from modelx_cython.parser import ModuleVisitor
 from modelx_cython.transformer import ModuleTransformer, PXDGenerator
 from modelx_cython.usage import analyze_usage, apply_verdicts
 
+_logger = logging.getLogger(__name__)
+
 
 def increment_backups(
         base_path: pathlib.Path,
@@ -161,6 +163,20 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
         # so that get_rettype_expr can fall back to object where needed.
         pairs = [(u.visitor, u.module_info) for u in units]
         apply_verdicts(pairs, analyze_usage(pairs))
+
+        # Cells called with keyword arguments anywhere in the model must
+        # keep plain Python public methods: Cython C-level calls are
+        # positional-only.
+        kwarg_names = set().union(
+            *(u.visitor.kwarg_called_names for u in units))
+        for u in units:
+            for cls_info in u.module_info.classes.values():
+                for cells in cls_info.cells.values():
+                    if cells.name in kwarg_names:
+                        cells.called_with_kwargs = True
+                        _logger.info(
+                            f"{cells.fqname} stays a Python method because "
+                            "a call with keyword arguments matches its name")
 
         # Phase 3: transform and write out
         for u in units:

--- a/modelx_cython/cli.py
+++ b/modelx_cython/cli.py
@@ -128,12 +128,21 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
 
         modules = [rel_model_path / (MX_SYS_MOD + ".py")]
 
-        # Phase 1: parse all sources and build all module infos
+        # Phase 1: parse all sources and build all module infos.
+        # Every model/space module is translated, including those whose
+        # cells the sample never exercised (e.g. enum-only spaces):
+        # other modules may reference their classes in pxd declarations,
+        # so their pxd files must exist.
         units = []
-        for m in logger.modules:
+        for m, src_path in iter_module_files(model_path):
             subs = m.split(".")
             assert subs.pop(0) == model_path.name
             assert subs[-1] in [MX_MODEL_MOD, MX_SPACE_MOD]
+            if subs[-1] == MX_MODEL_MOD and m not in logger.modules:
+                # The model module defines the model class, which the
+                # transformer does not handle; it is translated only when
+                # the sample traced cells in it.
+                continue
             pxd_path = subs.copy()
             subs[-1] = subs[-1] + ".py"
             pxd_path[-1] = pxd_path[-1] + ".pxd"
@@ -150,15 +159,7 @@ def main_handler(args: argparse.Namespace, stdout: IO[str], stderr: IO[str]) -> 
 
         # Phase 2: classify cross-module usage of array-returning cells
         # so that get_rettype_expr can fall back to object where needed.
-        # Modules whose cells the sample never exercised are not transformed,
-        # but their formulas may still consume traced cells, so they are
-        # parsed for the analysis as well.
         pairs = [(u.visitor, u.module_info) for u in units]
-        traced = {u.fqname for u in units}
-        for m, src_path in iter_module_files(model_path):
-            if m not in traced:
-                visitor = ModuleVisitor(module=m, source=src_path.read_text(encoding="utf-8"))
-                pairs.append((visitor, ModuleInfo(m, visitor, logger, spec)))
         apply_verdicts(pairs, analyze_usage(pairs))
 
         # Phase 3: transform and write out

--- a/modelx_cython/parser.py
+++ b/modelx_cython/parser.py
@@ -108,6 +108,7 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
         self.classes = []
         self.spaces = {}  # Parent class name to list of child space names
         self.cimports = []
+        self.formula_defs = {}  # {class_name: set of cells names with _f_ defs}
         self.wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))
         self.wrapper.visit(self)
 
@@ -181,7 +182,9 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
 
             if original_node.name.value[: len(FORMULA_PREF)] == FORMULA_PREF:
                 # _f_ methods
-                pass
+                name = original_node.name.value
+                self.formula_defs.setdefault(cls_name, set()).add(
+                    name[len(FORMULA_PREF):])
             elif original_node.name.value[: len(GLOBAL_PREF)] == GLOBAL_PREF:
                 # _mx_ methods
                 pass

--- a/modelx_cython/parser.py
+++ b/modelx_cython/parser.py
@@ -109,8 +109,27 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
         self.spaces = {}  # Parent class name to list of child space names
         self.cimports = []
         self.formula_defs = {}  # {class_name: set of cells names with _f_ defs}
+        self.closure_funcs = {}  # {class_name: set of method names containing closures}
+        self.generator_funcs = {}  # {class_name: set of method names containing yield}
         self.wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))
         self.wrapper.visit(self)
+
+    _closure_matcher = (
+        m.FunctionDef() | m.Lambda() | m.GeneratorExp() | m.Yield())
+
+    def _has_closure(self, funcdef: cst.FunctionDef) -> bool:
+        """True if the function body contains a construct that Cython
+        compiles as a closure (nested function, lambda, generator
+        expression or yield), which is not supported inside cpdef
+        (ccall) functions. cdef (cfunc) functions support closures."""
+        return bool(m.findall(funcdef.body, self._closure_matcher))
+
+    def _is_generator(self, funcdef: cst.FunctionDef) -> bool:
+        """True if the function body contains a yield, which is not
+        supported inside either cdef or cpdef functions. A yield inside
+        a nested def is a rare false positive; the resulting fallback to
+        a plain Python method is safe."""
+        return bool(m.findall(funcdef.body, m.Yield()))
 
     @m.leave(m.ClassDef())
     def collect_classes(self, original_node):
@@ -185,6 +204,8 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
                 name = original_node.name.value
                 self.formula_defs.setdefault(cls_name, set()).add(
                     name[len(FORMULA_PREF):])
+                if self._is_generator(original_node):
+                    self.generator_funcs.setdefault(cls_name, set()).add(name)
             elif original_node.name.value[: len(GLOBAL_PREF)] == GLOBAL_PREF:
                 # _mx_ methods
                 pass
@@ -203,6 +224,8 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
                              + original_node.params.posonly_params
                     if p.name.value != MX_SELF
                 ]
+                if self._has_closure(original_node):
+                    self.closure_funcs.setdefault(cls_name, set()).add(name)
 
                 ci = LexicalCellsInfo(
                     module=self.module,

--- a/modelx_cython/parser.py
+++ b/modelx_cython/parser.py
@@ -54,10 +54,12 @@ class LexicalBaseMemberInfo:
 class LexicalCellsInfo(LexicalBaseMemberInfo):
 
     params: Sequence[str]
+    params_with_defaults: Sequence[str]
 
-    def __init__(self, module, cls, name, params) -> None:
+    def __init__(self, module, cls, name, params, params_with_defaults=()) -> None:
         super().__init__(module, cls, name)
         self.params: Sequence[str] = params
+        self.params_with_defaults: Sequence[str] = params_with_defaults
 
     def is_special(self):
         return self.name[:2] == self.name[-2:] == "__"
@@ -113,6 +115,21 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
         self.generator_funcs = {}  # {class_name: set of method names containing yield}
         self.wrapper = cst.metadata.MetadataWrapper(cst.parse_module(source))
         self.wrapper.visit(self)
+        self.kwarg_called_names = self._collect_kwarg_called_names()
+
+    def _collect_kwarg_called_names(self):
+        """Names of functions/methods called with keyword arguments anywhere
+        in the module. Cython compiles C-level calls as positional-only, so
+        cells called with keyword arguments must stay plain Python methods."""
+        names = set()
+        for call in m.findall(self.wrapper.module, m.Call()):
+            if any(a.keyword is not None or a.star == "**" for a in call.args):
+                func = call.func
+                if isinstance(func, cst.Attribute):
+                    names.add(func.attr.value)
+                elif isinstance(func, cst.Name):
+                    names.add(func.value)
+        return names
 
     _closure_matcher = (
         m.FunctionDef() | m.Lambda() | m.GeneratorExp() | m.Yield())
@@ -218,11 +235,15 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
             else:
                 # cells
                 name = original_node.name.value
-                params = [
-                    p.name.value
+                param_nodes = [
+                    p
                     for p in original_node.params.params
                              + original_node.params.posonly_params
                     if p.name.value != MX_SELF
+                ]
+                params = [p.name.value for p in param_nodes]
+                params_with_defaults = [
+                    p.name.value for p in param_nodes if p.default is not None
                 ]
                 if self._has_closure(original_node):
                     self.closure_funcs.setdefault(cls_name, set()).add(name)
@@ -231,7 +252,8 @@ class ModuleVisitor(m.MatcherDecoratableVisitor, ParentScopeAddin):
                     module=self.module,
                     cls=cls_name,
                     name=name,
-                    params=params
+                    params=params,
+                    params_with_defaults=params_with_defaults
                 )
                 self.cells_info.setdefault(cls_name, {})[name]  = ci
 

--- a/modelx_cython/tests/samples/tradlife_a/assert_cy.py
+++ b/modelx_cython/tests/samples/tradlife_a/assert_cy.py
@@ -1,0 +1,13 @@
+import sys
+import math
+
+from TradLife_A_nomx import TradLife_A as nomx_model
+from TradLife_A_nomx_cy import TradLife_A as cy_model
+
+def run_model(m):
+    return [m.Projection[i].pv_net_cf(0) for i in range(0, 300, 10)]
+
+if __name__ == "__main__":
+    ok = all(math.isclose(a, b, rel_tol=1e-11)
+             for a, b in zip(run_model(nomx_model), run_model(cy_model)))
+    sys.exit(not int(ok))

--- a/modelx_cython/tests/samples/tradlife_a/sample.py
+++ b/modelx_cython/tests/samples/tradlife_a/sample.py
@@ -1,0 +1,4 @@
+from TradLife_A_nomx import TradLife_A
+
+for i in range(0, 300, 10):
+    TradLife_A.Projection[i].pv_net_cf(0)

--- a/modelx_cython/tests/samples/tradlife_a/spec.py
+++ b/modelx_cython/tests/samples/tradlife_a/spec.py
@@ -1,0 +1,16 @@
+{
+    "spaces": {
+        "CommTable": {
+            # The actuarial functions take multiple int params with large
+            # traced maxima (x, n, f up to ~115), so array caching would
+            # allocate huge N-D arrays; store these cells in dicts instead.
+            "cells": {
+                "AnnDuenx": {"return_type": "object"},
+                "AnnDuex": {"return_type": "object"},
+                "Ax": {"return_type": "object"},
+                "Axn": {"return_type": "object"},
+                "Exn": {"return_type": "object"}
+            }
+        }
+    }
+}

--- a/modelx_cython/tests/samples/tradlife_a_ex1/assert_cy.py
+++ b/modelx_cython/tests/samples/tradlife_a_ex1/assert_cy.py
@@ -1,0 +1,15 @@
+import sys
+import math
+
+from TradLife_A_EX1_nomx import TradLife_A_EX1 as nomx_model
+from TradLife_A_EX1_nomx_cy import TradLife_A_EX1 as cy_model
+
+def run_model(m):
+    values = [m.Projection[i].risk_life(0) for i in (0, 40, 101, 170, 250)]
+    values.append(m.Projection[0].risk_margin(0))
+    return values
+
+if __name__ == "__main__":
+    ok = all(math.isclose(a, b, rel_tol=1e-11)
+             for a, b in zip(run_model(nomx_model), run_model(cy_model)))
+    sys.exit(not int(ok))

--- a/modelx_cython/tests/samples/tradlife_a_ex1/sample.py
+++ b/modelx_cython/tests/samples/tradlife_a_ex1/sample.py
@@ -1,0 +1,6 @@
+from TradLife_A_EX1_nomx import TradLife_A_EX1
+
+for i in (0, 40, 101, 170, 250):
+    TradLife_A_EX1.Projection[i].risk_life(0)
+
+TradLife_A_EX1.Projection[0].risk_margin(0)

--- a/modelx_cython/tests/samples/tradlife_a_ex1/spec.py
+++ b/modelx_cython/tests/samples/tradlife_a_ex1/spec.py
@@ -1,0 +1,31 @@
+{
+    "spaces": {
+        "CommTable": {
+            # The actuarial functions take multiple int params with large
+            # traced maxima (x, n, f up to ~115), so array caching would
+            # allocate huge N-D arrays; store these cells in dicts instead.
+            "cells": {
+                "AnnDuenx": {"return_type": "object"},
+                "AnnDuex": {"return_type": "object"},
+                "Ax": {"return_type": "object"},
+                "Axn": {"return_type": "object"},
+                "Exn": {"return_type": "object"}
+            }
+        },
+        "Projection": {
+            # The sampled policies never reach maturity (their projections
+            # end at the mortality-table limit), so pols_maturity is traced
+            # as int although its maturity branch returns a float.
+            "cells": {
+                "pols_maturity": {"return_type": "float"}
+            },
+            "spaces": {
+                "InnerProj": {
+                    "cells": {
+                        "pols_maturity": {"return_type": "float"}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modelx_cython/tests/test_annuallife.py
+++ b/modelx_cython/tests/test_annuallife.py
@@ -1,0 +1,45 @@
+import sys
+import os
+import subprocess
+import pathlib
+import shutil
+import pytest
+
+
+@pytest.fixture
+def sample_dir(tmp_path_factory, request):
+    sample = request.param
+    dst = tmp_path_factory.mktemp("temp") / "samples" / sample
+    shutil.copytree(pathlib.Path(__file__).parent / "samples" / sample, dst)
+    return dst
+
+
+@pytest.mark.parametrize("sample_dir, model", [["tradlife_a", "TradLife_A"],
+                                               ["tradlife_a_ex1", "TradLife_A_EX1"]],
+                         indirect=["sample_dir"])
+def test_mx2cy_with_annuallife(sample_dir, model):
+    import lifelib
+    import modelx as mx
+
+    work_dir = sample_dir
+    lifelib.create('annuallife', work_dir / 'annuallife')
+
+    mx.read_model(work_dir / 'annuallife' / model).export(work_dir / (model + '_nomx'))
+    del mx.get_models()[model]
+
+    # The exported model loads input.xlsx from its parent directory
+    shutil.copy(work_dir / 'annuallife' / 'input.xlsx', work_dir)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(work_dir) + os.pathsep + env.get("PYTHONPATH", "")
+
+    argv = ["mx2cy", str(work_dir / (model + "_nomx")),
+            "--spec", str(work_dir / "spec.py"),
+            "--sample", str(work_dir / "sample.py")]
+
+    assert subprocess.run(argv, env=env).returncode == 0
+
+    assert subprocess.run(
+        [sys.executable, str(work_dir / "assert_cy.py")],
+        env=env
+    ).returncode == 0

--- a/modelx_cython/transformer.py
+++ b/modelx_cython/transformer.py
@@ -163,6 +163,10 @@ class PXDGenerator:
 
             assert ref.module == self.module.fqname and ref.cls == cls_name
 
+            if ref.name in self.module.classes[cls_name].spaces:
+                # declared below as a child space
+                continue
+
             stmt = f"cdef public {ref.get_type_expr(c_style=True)} {ref.name}\n"
             decl_stmts.append(stmt)
 
@@ -356,6 +360,10 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
             for ref in self.module.classes[cls_name].refs.values():
 
                 assert ref.module == self.module.fqname and ref.cls == cls_name
+
+                if ref.name in self.module.classes[cls_name].spaces:
+                    # declared below as a child space
+                    continue
 
                 stmt = cst.parse_statement(
                     f"{ref.name}: {ref.get_type_expr()}",

--- a/modelx_cython/transformer.py
+++ b/modelx_cython/transformer.py
@@ -135,6 +135,11 @@ class PXDGenerator:
             if cells.is_special():
                 continue
 
+            if not cells.has_formula_def:
+                # uncached cells: the public method is the formula itself
+                # and no cache storage exists
+                continue
+
             if cells.has_args():
                 if cells.has_typeinfo() and cells.is_arrayable():
 
@@ -204,6 +209,10 @@ class PXDGenerator:
         for cells in self.module.classes[cls_name].cells.values():
 
             if cells.is_special():
+                continue
+
+            if not cells.has_formula_def:
+                # no _f_ method exists
                 continue
 
             if cells and cells.has_typeinfo():
@@ -309,6 +318,11 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
                 assert cells.cls == cls_name
 
                 if cells.is_special():
+                    continue
+
+                if not cells.has_formula_def:
+                    # uncached cells: the public method is the formula itself
+                    # and no cache storage exists
                     continue
 
                 if cells.has_args():
@@ -590,6 +604,14 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
                     parameters = self._add_param_type_hints(
                         updated_node, cls_name=cls_name
                     )
+                    if not cells.has_formula_def:
+                        # uncached cells: the body is the formula itself;
+                        # leave it untouched
+                        return updated_node.with_changes(
+                            decorators=decorators,
+                            params=parameters,
+                            returns=returns,
+                        )
                     if cells.has_typeinfo() and cells.is_arrayable():
 
                         # Construct indented_block to replace the original one

--- a/modelx_cython/transformer.py
+++ b/modelx_cython/transformer.py
@@ -211,8 +211,8 @@ class PXDGenerator:
             if cells.is_special():
                 continue
 
-            if not cells.has_formula_def:
-                # no _f_ method exists
+            if not cells.has_formula_def or cells.formula_is_generator:
+                # no _f_ method exists, or it stays a plain Python method
                 continue
 
             if cells and cells.has_typeinfo():
@@ -239,6 +239,10 @@ class PXDGenerator:
         for cells in self.module.classes[cls_name].cells.values():
 
             if cells.is_special():
+                continue
+
+            if cells.body_has_closure:
+                # stays a plain Python method
                 continue
 
             if cells and cells.has_typeinfo():
@@ -517,6 +521,11 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
                 # _f_ methods
                 cells = cls_info.cells.get(meth_name[len(FORMULA_PREF):])
 
+                if cells.formula_is_generator:
+                    # yield is not supported inside cdef functions;
+                    # leave as a plain Python method
+                    return updated_node
+
                 decorators = [
                     cst.Decorator(
                         decorator=cst.Attribute(
@@ -584,6 +593,11 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
             else:
                 # cells
                 cells: CombinedCellsInfo = cls_info.cells[meth_name]
+
+                if cells.body_has_closure:
+                    # closures cannot be compiled inside cpdef functions;
+                    # leave as a plain Python method
+                    return updated_node
 
                 decorators = [
                     cst.Decorator(

--- a/modelx_cython/transformer.py
+++ b/modelx_cython/transformer.py
@@ -192,14 +192,17 @@ class PXDGenerator:
         cells = self.module.classes[cls_name].cells[cells_name]
         params = [f"{cls_name} {MX_SELF}"]  # add self first
 
-        # Add parameter type hints
+        # Add parameter type hints. Parameters with default values are
+        # marked with '=*' as required for pxd declarations.
         if cells and cells.has_typeinfo() and cells.has_args():
             for param in cells.params:
                 type_ = cells.get_argtype_expr(param, c_style=True)
-                params.append(f"{type_} {param}")
+                default = "=*" if param in cells.params_with_defaults else ""
+                params.append(f"{type_} {param}{default}")
         else:
             for p in cells.params:
-                params.append(f"object {p}")
+                default = "=*" if p in cells.params_with_defaults else ""
+                params.append(f"object {p}{default}")
 
         return ", ".join(params)
 
@@ -241,7 +244,7 @@ class PXDGenerator:
             if cells.is_special():
                 continue
 
-            if cells.body_has_closure:
+            if cells.body_has_closure or cells.called_with_kwargs:
                 # stays a plain Python method
                 continue
 
@@ -599,13 +602,19 @@ class ModuleTransformer(m.MatcherDecoratableTransformer, ParentScopeAddin):
                     # leave as a plain Python method
                     return updated_node
 
-                decorators = [
-                    cst.Decorator(
-                        decorator=cst.Attribute(
-                            value=cst.Name(CY_MOD), attr=cst.Name("ccall")
+                if cells.called_with_kwargs:
+                    # C-level calls are positional-only, so a cells called
+                    # with keyword arguments keeps a plain Python public
+                    # method (its _f_ formula stays compiled)
+                    decorators = []
+                else:
+                    decorators = [
+                        cst.Decorator(
+                            decorator=cst.Attribute(
+                                value=cst.Name(CY_MOD), attr=cst.Name("ccall")
+                            )
                         )
-                    )
-                ]
+                    ]
                 # Return type
                 returns = cst.Annotation(
                     annotation=cst.parse_expression(


### PR DESCRIPTION
## What

Adds integration tests that build `TradLife_A` and `TradLife_A_EX1` from lifelib's `annuallife` library and verify the mx2cy-compiled models against the pure-Python exports, plus the six translator fixes those models required. One commit per fix:

1. **UTF-8 I/O** (`682d026`) — model sources were read/written with the locale encoding; on a cp932 locale, reading a model with non-ASCII docstrings crashed.
2. **Array-size merge fix** (`2980880`) — per-signature max args were merged into a local dict that was never written back, so shared cache arrays were sized by the first cells of a signature group (`Cx`, max x 109) instead of the true max (`Mx`/`Nx`/`lx`, 130) and raised `IndexError` at runtime.
3. **Translate all space modules** (`eac3866`) — enum-only spaces (`Enums.ProductID`, `LifeRiskID`, ...) have no cells and no parameters, so they can never be traced, yet traced modules reference their classes in typed pxd declarations. All space modules found on disk are now translated (`_mx_model` keeps its traced-only rule). Includes the ref/child-space name dedup and an `object` fallback for refs with no sampled type.
4. **Uncached cells** (`3ff2430`) — cells exported without a `_f_` method (e.g. `InputData.get_named_range_as_df`) got phantom `_f_`/storage declarations in the pxd.
5. **Closures** (`f0066d2`) — public (ccall) methods containing closures (genexpr in `get_named_range_as_dict`) stay plain Python; `_f_` formulas keep compiling as cfunc (Cython allows closures there — e.g. the genexprs in `risk_life`), falling back only for generator formulas containing `yield`.
6. **Defaults and keyword calls** (`1ee2b72`) — `AnnDuenx(x, n, k=1, f=0)` needs `=*` markers in the pxd, and `life_shock_param(risk, shock, extra_key=...)` skips a middle default via a keyword, which C-level (positional-only) calls cannot express; such cells keep a plain Python public method, logged at INFO.

## Test design

- Like the BasicTerm tests, the models come from lifelib at test time (`lifelib.create('annuallife', ...)` → `mx.read_model(...).export(...)`), not from files stored in this repo. `input.xlsx` is copied next to the export because the model loads it from `_model.path.parent`.
- `sample.py` traces exactly the policies `assert_cy.py` runs, so traced cache-array sizes always cover the assert run. TradLife_A compares `pv_net_cf(0)` over 30 policies; TradLife_A_EX1 compares `risk_life(0)` over 5 policies plus `risk_margin(0)`, all at `rel_tol=1e-11`.
- The specs exercise `return_type` overrides: `"object"` for CommTable's multi-int-param cells (array caching would allocate ~240 MB of N-D arrays per instance) and `"float"` for `pols_maturity`, whose maturity branch the sampled policies never reach.

## Reviewer notes

- The keyword-call demotion matches by *name* across the whole model, so an unrelated same-named call demotes a cells needlessly (correctness is unaffected; the demotion is logged). Verified empirically that removing this logic reproduces the Cython missing-argument errors on Cython 3.2.4.
- Full suite passes locally: 85 passed, 7 skipped (pre-existing skips), ~5 min including the two new tests (~80 s).
- Requires a lifelib with the `annuallife` library for the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
