### PR TITLE
Switch docs to pydata-sphinx-theme and restructure for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt
+    # Install the package itself so autodoc can import modelx_cython
+    # together with its runtime dependencies (modelx, libcst, etc.).
+    - method: pip
+      path: .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,4 +6,4 @@
 #   sphinx-build -b html doc/source doc/build/html
 sphinx>=7
 myst-parser>=2
-sphinx-rtd-theme>=2
+pydata-sphinx-theme>=0.15

--- a/doc/source/api/index.md
+++ b/doc/source/api/index.md
@@ -1,4 +1,4 @@
-# API reference
+# Module reference
 
 This section documents the modules of the `modelx_cython` package.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,8 +68,17 @@ intersphinx_mapping = {
 # -- Options for HTML output -------------------------------------------------
 
 try:
-    import sphinx_rtd_theme  # noqa: F401
+    import pydata_sphinx_theme  # noqa: F401
 
-    html_theme = "sphinx_rtd_theme"
+    html_theme = "pydata_sphinx_theme"
+    html_theme_options = {
+        "icon_links": [
+            {
+                "name": "GitHub",
+                "url": "https://github.com/fumitoh/modelx-cython",
+                "icon": "fa-brands fa-github",
+            },
+        ],
+    }
 except ImportError:
     html_theme = "alabaster"

--- a/doc/source/implementation.md
+++ b/doc/source/implementation.md
@@ -1,0 +1,12 @@
+# Implementation details
+
+This section is for developers who want to understand how modelx-cython
+works internally or contribute to it.  Regular users of the
+{doc}`mx2cy <cli>` command do not need to read it.
+
+```{toctree}
+:maxdepth: 2
+
+architecture
+api/index
+```

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -32,8 +32,7 @@ installation
 tutorial
 cli
 spec
-architecture
-api/index
+implementation
 ```
 
 ## See also


### PR DESCRIPTION
## Summary
- Switch the Sphinx HTML theme from sphinx-rtd-theme to pydata-sphinx-theme (with a GitHub icon link in the header)
- Add `.readthedocs.yaml` so the docs can be hosted on readthedocs.org
- Group the Architecture and module documentation under a new "Implementation details" section aimed at developers, and retitle "API reference" to "Module reference"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
